### PR TITLE
Update to the latest AVR32 Toolchain patches and headers (binutils 2.22 version)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,14 @@
 
 GCC_VERSION      = 4.4.3
 GDB_VERSION      = 6.7.1
-BINUTILS_VERSION = 2.20.1
+BINUTILS_VERSION = 2.22
 NEWLIB_VERSION   = 1.16.0
 DFU_VERSION      = 0.5.4
-AVR_PATCH_REV	 = 3.3.2.321
-AVR_HEADER_REV   = 3.2.3.258
+AVR_PATCH_REV	 = 3.4.0.332
+
+# Deprecated. Atmel has released the latest headers without the rev number.
+# Moreover AVR32 headers are now bundled with the AVR8 headers.
+#AVR_HEADER_REV   = 3.2.3.258
 
 
 #### PATHS AND ENVIRONMENT VARIABLES #####
@@ -74,19 +77,19 @@ GDB_MD5 = 30a6bf36eded4ae5a152d7d71b86dc14
 
 BINUTILS_ARCHIVE = binutils-$(BINUTILS_VERSION).tar.bz2
 BINUTILS_URL = http://mirror.anl.gov/pub/gnu/binutils/$(BINUTILS_ARCHIVE)
-BINUTILS_MD5 = 2b9dc8f2b7dbd5ec5992c6e29de0b764
+BINUTILS_MD5 = ee0f10756c84979622b992a4a61ea3f5
 
 NEWLIB_ARCHIVE = newlib-$(NEWLIB_VERSION).tar.gz
 NEWLIB_URL = ftp://sources.redhat.com/pub/newlib/$(NEWLIB_ARCHIVE)
 NEWLIB_MD5 = bf8f1f9e3ca83d732c00a79a6ef29bc4
 
 AVR32PATCHES_ARCHIVE = avr32-gnu-toolchain-$(AVR_PATCH_REV)-source.zip
-AVR32PATCHES_URL=http://www.atmel.com/dyn/resources/prod_documents/$(AVR32PATCHES_ARCHIVE)
-AVR32PATCHES_MD5 = 68fe4f7a4b8f19183a3be0ce84a75425
+AVR32PATCHES_URL = http://www.atmel.com/Images/$(AVR32PATCHES_ARCHIVE)
+AVR32PATCHES_MD5 = 376926e2b4f889b4c422d4e1d3a7c4b6
 
-AVR32HEADERS_ARCHIVE = avr32-headers-$(AVR_HEADER_REV).zip
-AVR32HEADERS_URL=http://www.atmel.com/dyn/resources/prod_documents/$(AVR32HEADERS_ARCHIVE)
-AVR32HEADERS_MD5 = 3293d70a46e460d342e1f939b8e0d228
+AVR32HEADERS_ARCHIVE = avr-headers.zip
+AVR32HEADERS_URL = http://www.atmel.com/Images/$(AVR32HEADERS_ARCHIVE)
+AVR32HEADERS_MD5 = 4e0172ea92507c51bdb3b18eca3de2c8
 
 DFU_ARCHIVE = dfu-programmer-$(DFU_VERSION).tar.gz
 DFU_URL = http://surfnet.dl.sourceforge.net/project/dfu-programmer/dfu-programmer/$(DFU_VERSION)/$(DFU_ARCHIVE)
@@ -241,14 +244,20 @@ extract-avr32patches stamps/extract-avr32patches : downloads/$(AVR32PATCHES_ARCH
 downloads/$(AVR32HEADERS_ARCHIVE) download-avr32headers:
 	cd downloads && curl -LO $(AVR32HEADERS_URL)
 
-.PHONY: install-headers
-install-headers stamps/install-headers : downloads/$(AVR32HEADERS_ARCHIVE) stamps/install-final-gcc
+.PHONY: extract-headers
+extract-headers stamps/extract-headers : downloads/$(AVR32HEADERS_ARCHIVE)
 	@(t1=`openssl md5 $< | cut -f 2 -d " " -` && \
 	[ "$$t1" = "$(AVR32HEADERS_MD5)" ] || \
 	( echo "Bad Checksum! Please remove the following file and retry: $<" && false ))
-	unzip -o $< -d "$(PREFIX)/$(TARGET)/include/" && \
-	[ -d stamps ] || mkdir stamps
-	touch stamps/install-headers;
+	unzip -o $<
+	mkdir -p stamps
+	touch stamps/extract-headers
+
+.PHONY: install-headers
+install-headers stamps/install-headers : stamps/extract-headers stamps/install-final-gcc
+	cp -r avr-headers/* $(PREFIX)/$(TARGET)/include/
+	mkdir -p stamps
+	touch stamps/install-headers
 
 
 ################ NEWLIB ################

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ extract-headers stamps/extract-headers : downloads/$(AVR32HEADERS_ARCHIVE)
 
 .PHONY: install-headers
 install-headers stamps/install-headers : stamps/extract-headers stamps/install-final-gcc
-	cp -r avr-headers/* $(PREFIX)/$(TARGET)/include/
+	cp -r avr-headers/$(TARGET) $(PREFIX)/$(TARGET)/include/$(TARGET)
 	mkdir -p stamps
 	touch stamps/install-headers
 
@@ -605,4 +605,4 @@ cross-gdb: gdb-$(CS_BASE)/
 
 .PHONY : clean
 clean:
-	rm -rf build *-$(CS_BASE) binutils-* gcc-* gdb-* newlib-* mpc-* $(LOCAL_BASE) dfu-programmer-* autoconf-* automake-* stamps/* source supp
+	rm -rf build *-$(CS_BASE) binutils-* gcc-* gdb-* newlib-* mpc-* $(LOCAL_BASE) dfu-programmer-* autoconf-* automake-* stamps source supp avr-headers


### PR DESCRIPTION
```
$ avr32-gcc --version
avr32-gcc (AVR 32 bit GNU Toolchain-3.4.0.332-655f90f) 4.4.3
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Resolves gh-14 too.
