### PR TITLE
Add a patch which disabled typeid-based getters in shared_ptr.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,6 +465,7 @@ patch-gcc stamps/patch-gcc: stamps/extract-gcc stamps/extract-avr32patches
 	for f in ../source/avr32/gcc/*.patch; do \
 	patch -N -p0 <$${f} ; \
 	done ; \
+	patch -N -p0 <../patches/gcc/00-libstdc++-shared_ptr-without-rtti-bug-42019.patch ; \
 	popd ;
 	[ -d stamps ] || mkdir stamps
 	touch stamps/patch-gcc;

--- a/patches/gcc/00-libstdc++-shared_ptr-without-rtti-bug-42019.patch
+++ b/patches/gcc/00-libstdc++-shared_ptr-without-rtti-bug-42019.patch
@@ -1,0 +1,96 @@
+diff -ru libstdc++-v3.old/include/bits/shared_ptr.h libstdc++-v3/include/bits/shared_ptr.h
+--- libstdc++-v3.old/include/bits/shared_ptr.h	2013-01-17 13:14:29.000000000 +0100
++++ libstdc++-v3/include/bits/shared_ptr.h	2013-01-17 13:14:35.000000000 +0100
+@@ -143,7 +143,13 @@
+       
+       virtual void*
+       _M_get_deleter(const std::type_info& __ti)
+-      { return __ti == typeid(_Deleter) ? &_M_del._M_del : 0; }
++      {
++#ifdef __GXX_RTTI
++        return __ti == typeid(_Deleter) ? &_M_del._M_del : 0;
++#else
++        return 0;
++#endif
++      }
+       
+     protected:
+       _My_Deleter      _M_del;  // copy constructor must not throw
+@@ -201,9 +207,13 @@
+       virtual void*
+       _M_get_deleter(const std::type_info& __ti)
+       {
++#ifdef __GXX_RTTI
+         return __ti == typeid(_Sp_make_shared_tag)
+                ? static_cast<void*>(&_M_storage)
+                : _Base_type::_M_get_deleter(__ti);
++#else
++        return 0;
++#endif
+       }
+       
+     private:
+@@ -850,6 +860,7 @@
+         { return _M_refcount._M_less(__rhs._M_refcount); }
+ 
+     protected:
++#ifdef __GXX_RTTI
+       // This constructor is non-standard, it is used by allocate_shared.
+       template<typename _Alloc, typename... _Args>
+         __shared_ptr(_Sp_make_shared_tag __tag, _Alloc __a, _Args&&... __args)
+@@ -862,6 +873,7 @@
+           _M_ptr = static_cast<_Tp*>(__p);
+ 	  __enable_shared_from_this_helper(_M_refcount, _M_ptr, _M_ptr);
+         }
++#endif
+ 
+       template<typename _Tp1, _Lock_policy _Lp1, typename _Alloc,
+                typename... _Args>
+@@ -1002,7 +1014,13 @@
+   template<typename _Del, typename _Tp, _Lock_policy _Lp>
+     inline _Del*
+     get_deleter(const __shared_ptr<_Tp, _Lp>& __p)
+-    { return static_cast<_Del*>(__p._M_get_deleter(typeid(_Del))); }
++    {
++#ifdef __GXX_RTTI
++      return static_cast<_Del*>(__p._M_get_deleter(typeid(_Del)));
++#else
++      return 0;
++#endif
++    }
+ 
+ 
+   template<typename _Tp, _Lock_policy _Lp>
+diff -ru libstdc++-v3.old/include/tr1/shared_ptr.h libstdc++-v3/include/tr1/shared_ptr.h
+--- libstdc++-v3.old/include/tr1/shared_ptr.h	2013-01-17 13:14:30.000000000 +0100
++++ libstdc++-v3/include/tr1/shared_ptr.h	2013-01-17 13:14:48.000000000 +0100
+@@ -76,7 +76,13 @@
+       
+       virtual void*
+       _M_get_deleter(const std::type_info& __ti)
+-      { return __ti == typeid(_Deleter) ? &_M_del : 0; }
++      {
++#ifdef __GXX_RTTI
++        return __ti == typeid(_Deleter) ? &_M_del : 0;
++#else
++        return 0;
++#endif
++      }
+       
+     private:
+       _Sp_counted_base_impl(const _Sp_counted_base_impl&);
+@@ -639,7 +645,13 @@
+   template<typename _Del, typename _Tp, _Lock_policy _Lp>
+     inline _Del*
+     get_deleter(const __shared_ptr<_Tp, _Lp>& __p)
+-    { return static_cast<_Del*>(__p._M_get_deleter(typeid(_Del))); }
++    {
++#ifdef __GXX_RTTI
++      return static_cast<_Del*>(__p._M_get_deleter(typeid(_Del)));
++#else
++      return 0;
++#endif
++    }
+ 
+ 
+   template<typename _Tp, _Lock_policy _Lp>


### PR DESCRIPTION
This enables the use of -fno-rtti to decrease the binary footprint. See original bug report at http://gcc.gnu.org/bugzilla/show_bug.cgi?id=42019.
